### PR TITLE
saving to default location named as input pcap (without file-extension)

### DIFF
--- a/pkt2flow.c
+++ b/pkt2flow.c
@@ -54,7 +54,7 @@
 static uint32_t dump_allowed;
 static char *readfile = NULL;
 //char *interface = NULL;
-static char *outputdir = "pkt2flow.out";
+static char *outputdir = NULL;
 static pcap_t *inputp = NULL;
 struct ip_pair *pairs[HASH_TBL_SIZE];
 
@@ -104,13 +104,17 @@ static void parseargs(int argc, char *argv[])
 	char *outdir, *lastdot;
 	if (optind < argc) {
 		readfile = argv[optind];
-	    if ((outdir = malloc(strlen(readfile) + 1)) != NULL ) {
-			strcpy(outdir, readfile);
-			if ((lastdot = strrchr(outdir, '.')) != NULL) {
-				*lastdot = '\0';
-				outputdir = outdir;
-			}
-	    }
+		if (outputdir == NULL) {
+		    if ( (outdir = malloc(strlen(readfile) + 1)) != NULL ) {
+				strcpy(outdir, readfile);
+				if ((lastdot = strrchr(outdir, '.')) != NULL) {
+					*lastdot = '\0';
+					outputdir = outdir;
+				}
+		    } else {
+		    	outputdir = "pkt2flow.out";
+		    }
+		}
 	}
 	if (readfile == NULL) {
 		fprintf(stderr, "pcap file not given\n");

--- a/pkt2flow.c
+++ b/pkt2flow.c
@@ -101,8 +101,17 @@ static void parseargs(int argc, char *argv[])
 		}
 	}
 
-	if (optind < argc)
+	char *outdir, *lastdot;
+	if (optind < argc) {
 		readfile = argv[optind];
+	    if ((outdir = malloc(strlen(readfile) + 1)) != NULL ) {
+			strcpy(outdir, readfile);
+			if ((lastdot = strrchr(outdir, '.')) != NULL) {
+				*lastdot = '\0';
+				outputdir = outdir;
+			}
+	    }
+	}
 	if (readfile == NULL) {
 		fprintf(stderr, "pcap file not given\n");
 		usage(argv[0]);


### PR DESCRIPTION
I think it's a good idea to name the output folder less generic. Therefore I created this small patch to derive a folder name from the input filename.